### PR TITLE
Add synclabs keyword and fix the end of the init block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
-All notable changes to the "imitator-language" extension will be documented in this file.
+All notable changes to the "imitator-language" extension will be documented in
+this file.
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 # IMITATOR language support for VS code
 
-This package proposes a language support for IMITATOR files in VS Code.
+This package proposes a language support for
+[IMITATOR](https://www.imitator.fr/) files in VS Code.
 
 ## Installation from sources
 
-- Clone the repository in `~/.vscode/extensions`: `git clone git@github.com:DylanMarinho/vscode-IMITATOR.git imitator-language`
+- Clone the repository in `~/.vscode/extensions`:\
+`git clone git@github.com:DylanMarinho/vscode-IMITATOR.git imitator-language`
 - Add the following instruction in the `.vscode/.extensions/extensions.json` file, before the end `]` and using your own `[USER]` name:
 
-```
-{"identifier":{"id":"undefined_publisher.imitator-language"},"version":"0.0.1","location":{"$mid":1,"fsPath":"/home/[USER]/.vscode/extensions/imitator-language","external":"file:///home/[USER]/.vscode/extensions/imitator-language","path":"/home/[USER]/.vscode/extensions/imitator-language","scheme":"file"},"relativeLocation":"imitator-language"}
+```json
+{
+  "identifier": {
+    "id": "undefined_publisher.imitator-language"
+  },
+  "version": "0.0.1",
+  "location": {
+    "$mid": 1,
+    "fsPath": "/home/[USER]/.vscode/extensions/imitator-language",
+    "external": "file:///home/[USER]/.vscode/extensions/imitator-language",
+    "path": "/home/[USER]/.vscode/extensions/imitator-language",
+    "scheme": "file"
+  },
+  "relativeLocation": "imitator-language"
+}
 ```
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This package proposes a language support for
 
 - Clone the repository in `~/.vscode/extensions`:\
 `git clone git@github.com:DylanMarinho/vscode-IMITATOR.git imitator-language`
-- Add the following instruction in the `.vscode/.extensions/extensions.json` file, before the end `]` and using your own `[USER]` name:
+- Add the following instruction in the `.vscode/.extensions/extensions.json`
+file, before the end `]` and using your own `[USER]` name:
 
 ```json
 {

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,30 +1,72 @@
 {
-    "comments": {
-        // symbol used for single line comment. Remove this entry if your language does not support line comments
-        // "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "(*", "*)" ]
-    },
-    // symbols used as brackets
-    "brackets": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"]
-    ],
-    // symbols that are auto closed when typing
-    "autoClosingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
-    ],
-    // symbols that can be used to surround a selection
-    "surroundingPairs": [
-        ["{", "}"],
-        ["[", "]"],
-        ["(", ")"],
-        ["\"", "\""],
-        ["'", "'"]
+  "comments": {
+    // symbol used for single line comment. Remove this entry if your language does not support line comments
+    // "lineComment": "//",
+    // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+    "blockComment": [
+      "(*",
+      "*)"
     ]
+  },
+  // symbols used as brackets
+  "brackets": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ],
+    [
+      "\"",
+      "\""
+    ],
+    [
+      "'",
+      "'"
+    ]
+  ],
+  // symbols that can be used to surround a selection
+  "surroundingPairs": [
+    [
+      "{",
+      "}"
+    ],
+    [
+      "[",
+      "]"
+    ],
+    [
+      "(",
+      ")"
+    ],
+    [
+      "\"",
+      "\""
+    ],
+    [
+      "'",
+      "'"
+    ]
+  ]
 }

--- a/syntaxes/imitator.property.tmLanguage.json
+++ b/syntaxes/imitator.property.tmLanguage.json
@@ -1,58 +1,64 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "IMITATOR model",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-        {
-			"include": "#property"
-		}
-    ],
-    "repository": {
-        "comments": {
-			"name": "comment.block",
-			"begin": "\\(\\*",
-			"end": "\\*\\)",
-			"patterns": [
-				{
-					"comment": "File metadata",
-					"match": "\\s+\\*\\s+(\\w+(\\s\\w+)*)\\s*\\:\\s*(.*)",
-					"captures":{
-					  "1":
-						  {"name": "markup.bold.imitator"},
-					  "3":
-						  {"name": "markup.italic.imitator"}
-					},
-					"name": "comment.block.imitator"
-				}
-			]
-		},
-        "property": {
-            "begin": "property",
-            "end": ";",
-            "beginCaptures": {"0": {"name": "keyword.control"}},
-            "patterns": [
-                {
-                    "include": "#comments"
-                },
-                {
-                    "comment": "Quantification",
-                    "match": "\\#\\b(synth|exhibit|witness|exemplify)\\b",
-                    "name": "keyword.control"
-                },
-                {
-                    "comment": "Property",
-                    "match": "\\b(EF|AGnot|EFpmin|EFpmax|EFtmin|CycleLoop|CycleThrough|LoopThrough|NZCycle|Valid|DeadlockFree|IM|InverseMethod|TracePreservation|IMconvex|IMK|IMunion|PRP|BCcover|BCshuffle|BCrandom|BCrandomseq|PRPC|Win|pattern)\\b",
-                    "name": "keyword.other"
-                },
-                {
-                    "comment": "Pattern",
-                    "match": "\\b(if|then|has happened before|everytime|within|has happened within|has happened one within|eventually|once before next|sequence|always)\\b",
-                    "name": "keyword.control"
-                }
-            ]
-        }
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "IMITATOR model",
+  "patterns": [
+    {
+      "include": "#comments"
     },
-    "scopeName": "source.imitator.property"
+    {
+      "include": "#property"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "name": "comment.block",
+      "begin": "\\(\\*",
+      "end": "\\*\\)",
+      "patterns": [
+        {
+          "comment": "File metadata",
+          "match": "\\s+\\*\\s+(\\w+(\\s\\w+)*)\\s*\\:\\s*(.*)",
+          "captures": {
+            "1": {
+              "name": "markup.bold.imitator"
+            },
+            "3": {
+              "name": "markup.italic.imitator"
+            }
+          },
+          "name": "comment.block.imitator"
+        }
+      ]
+    },
+    "property": {
+      "begin": "property",
+      "end": ";",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.control"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "comment": "Quantification",
+          "match": "\\#\\b(synth|exhibit|witness|exemplify)\\b",
+          "name": "keyword.control"
+        },
+        {
+          "comment": "Property",
+          "match": "\\b(EF|AGnot|EFpmin|EFpmax|EFtmin|CycleLoop|CycleThrough|LoopThrough|NZCycle|Valid|DeadlockFree|IM|InverseMethod|TracePreservation|IMconvex|IMK|IMunion|PRP|BCcover|BCshuffle|BCrandom|BCrandomseq|PRPC|Win|pattern)\\b",
+          "name": "keyword.other"
+        },
+        {
+          "comment": "Pattern",
+          "match": "\\b(if|then|has happened before|everytime|within|has happened within|has happened one within|eventually|once before next|sequence|always)\\b",
+          "name": "keyword.control"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.imitator.property"
 }

--- a/syntaxes/imitator.tmLanguage.json
+++ b/syntaxes/imitator.tmLanguage.json
@@ -71,7 +71,7 @@
 					},
 					{
 						"comment": "Actions declaration",
-						"begin": "actions",
+          "begin": "actions|synclabs",
 						"end": ";",
 						"beginCaptures": {
 							"0": {"name": "keyword.control"}

--- a/syntaxes/imitator.tmLanguage.json
+++ b/syntaxes/imitator.tmLanguage.json
@@ -1,197 +1,224 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "IMITATOR model",
-	"patterns": [
-		{
-			"include": "#comments"
-		},
-		{
-			"include": "#types"
-		},
-		{
-			"include": "#values"
-		},
-		{
-			"include": "#keywords"
-		},
-		{
-			"include": "#automaton"
-		},
-		{
-			"include": "#initial"
-		},
-		{
-			"include": "#strings"
-		}
-	],
-	"repository": {
-		"comments": {
-			"name": "comment.block",
-			"begin": "\\(\\*",
-			"end": "\\*\\)",
-			"patterns": [
-				{
-					"comment": "File metadata",
-					"match": "\\s+\\*\\s+(\\w+(\\s\\w+)*)\\s*\\:\\s*(.*)",
-					"captures":{
-					  "1":
-						  {"name": "markup.bold.imitator"},
-					  "3":
-						  {"name": "markup.italic.imitator"}
-					},
-					"name": "comment.block.imitator"
-				}
-			]
-		},
-		"types": {
-			"name": "storage.type",
-			"match": "\\b(clock|parameter|array|list|stack|queue|void|binary|bool|constant|discrete|int|rational)\\b"
-		},
-		"keywords": {
-			"patterns": [{
-				"name": "keyword.control.imitator",
-				"match": "\\b(var)\\b"
-			}
-			]
-		},
-		"automaton": {
-				"comment": "Automaton declaration",
-				"begin": "\\b(automaton)\\b (([a-zA-Z])+)",
-				"end": "end",
-				"beginCaptures": {
-					"1": {"name": "keyword.control.imitator"},
-					"2": {"name": "variable.other"}
-				},
-				"endCaptures": {
-					"0": {"name": "keyword.control.imitator"}
-				},
-				"patterns": [
-					{
-						"include": "#comments"
-					},
-					{
-						"comment": "Actions declaration",
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "IMITATOR model",
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#types"
+    },
+    {
+      "include": "#values"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#automaton"
+    },
+    {
+      "include": "#initial"
+    },
+    {
+      "include": "#strings"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "name": "comment.block",
+      "begin": "\\(\\*",
+      "end": "\\*\\)",
+      "patterns": [
+        {
+          "comment": "File metadata",
+          "match": "\\s+\\*\\s+(\\w+(\\s\\w+)*)\\s*\\:\\s*(.*)",
+          "captures": {
+            "1": {
+              "name": "markup.bold.imitator"
+            },
+            "3": {
+              "name": "markup.italic.imitator"
+            }
+          },
+          "name": "comment.block.imitator"
+        }
+      ]
+    },
+    "types": {
+      "name": "storage.type",
+      "match": "\\b(clock|parameter|array|list|stack|queue|void|binary|bool|constant|discrete|int|rational)\\b"
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.imitator",
+          "match": "\\b(var)\\b"
+        }
+      ]
+    },
+    "automaton": {
+      "comment": "Automaton declaration",
+      "begin": "\\b(automaton)\\b (([a-zA-Z])+)",
+      "end": "\\b(end)\\b",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.control.imitator"
+        },
+        "2": {
+          "name": "variable.other"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.control.imitator"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "comment": "Actions declaration",
           "begin": "actions|synclabs",
-						"end": ";",
-						"beginCaptures": {
-							"0": {"name": "keyword.control"}
-						}
-					},
-					{
-						"comment": "Location",
-						"match": "((accepting|urgent|\\s)*)\\s*(loc)\\s*(([a-zA-Z0-9])*)\\s*",
-						"captures": {
-							"1": {"name": "keyword.other"},
-							"3": {"name": "keyword.control"},
-							"4": {"name": "variable.other"}
-						},
-						"patterns": [
-							{
-								"include": "#values"
-							}
-						]
-					},
-					{
-						"comment": "Invariant",
-						"match": "\\b(invariant)\\b",
-						"name": "keyword.control"
-					},
-					{
-						"include": "#values"
-					},
-					{
-						"comment": "Transitions",
-						"begin": "when",
-						"end": ";",
-						"beginCaptures": {
-							"0": {"name": "keyword.control"}
-						},
-						"patterns": [
-							{
-								"match": "\\b(goto|sync|do)\\b",
-								"name": "keyword.control"
-							},
-							{
-								"include": "#values"
-							}
-						]
-					}
-				]
-		},
-		"initial": {
-			"comment": "Initial state",
-			"begin": "(init)",
-			"end": "(end)",
-			"beginCaptures": {
-				"0": {"name": "keyword.control"}
-			},
-			"endCaptures": {
-				"0": {"name": "keyword.control"}
-			},
-			"patterns": [
-				{
-					"include": "#comments"
-				},
-				{
-					"comment": "Discrete",
-					"begin": "discrete",
-					"end": ";",
-					"beginCaptures": {
-						"0": {"name": "keyword.control"}
-					},
-					"patterns": [
-						{
-							"include": "#comments"
-						},
-						{
-							"include": "#values"
-						}
-					]
-				},
-				{
-					"comment": "Continuous",
-					"begin": "continuous",
-					"end": ";",
-					"beginCaptures": {
-						"0": {"name": "keyword.control"}
-					},
-					"patterns": [
-						{
-							"include": "#comments"
-						},
-						{
-							"include": "#values"
-						}
-					]
-				}
-			]
-		},
-		"values": {
-			"comment": "Constants and values",
-			"patterns": [
-				{
-				  "comment": "Constants",
-				  "match": "[^\\w+][0-9]+\\.?[0-9]*",
-				  "name": "constant.numeric.imitator"
-				},
-				{
-				  "comment": "True and False",
-				  "match": "\\b(true|false|True|False)",
-				  "name": "constant.language.imitator"
-				}
-			]
-		},
-		"strings": {
-			"name": "string.quoted.double.imitator",
-			"begin": "\"",
-			"end": "\"",
-			"patterns": [
-				{
-					"name": "constant.character.escape.imitator",
-					"match": "\\\\."
-				}
-			]
-		}
-	},
-	"scopeName": "source.imitator"
+          "end": ";",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control"
+            }
+          }
+        },
+        {
+          "comment": "Location",
+          "match": "((accepting|urgent|\\s)*)\\s*(loc)\\s*(([a-zA-Z0-9])*)\\s*",
+          "captures": {
+            "1": {
+              "name": "keyword.other"
+            },
+            "3": {
+              "name": "keyword.control"
+            },
+            "4": {
+              "name": "variable.other"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#values"
+            }
+          ]
+        },
+        {
+          "comment": "Invariant",
+          "match": "\\b(invariant)\\b",
+          "name": "keyword.control"
+        },
+        {
+          "include": "#values"
+        },
+        {
+          "comment": "Transitions",
+          "begin": "when",
+          "end": ";",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\b(goto|sync|do)\\b",
+              "name": "keyword.control"
+            },
+            {
+              "include": "#values"
+            }
+          ]
+        }
+      ]
+    },
+    "initial": {
+      "comment": "Initial state",
+      "begin": "\\b(init)\\b",
+      "end": "\\b(end)\\b",
+      "beginCaptures": {
+        "0": {
+          "name": "keyword.control"
+        }
+      },
+      "endCaptures": {
+        "0": {
+          "name": "keyword.control"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "comment": "Discrete",
+          "begin": "discrete",
+          "end": ";",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#values"
+            }
+          ]
+        },
+        {
+          "comment": "Continuous",
+          "begin": "continuous",
+          "end": ";",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#values"
+            }
+          ]
+        }
+      ]
+    },
+    "values": {
+      "comment": "Constants and values",
+      "patterns": [
+        {
+          "comment": "Constants",
+          "match": "[^\\w+][0-9]+\\.?[0-9]*",
+          "name": "constant.numeric.imitator"
+        },
+        {
+          "comment": "True and False",
+          "match": "\\b(true|false|True|False)",
+          "name": "constant.language.imitator"
+        }
+      ]
+    },
+    "strings": {
+      "name": "string.quoted.double.imitator",
+      "begin": "\"",
+      "end": "\"",
+      "patterns": [
+        {
+          "name": "constant.character.escape.imitator",
+          "match": "\\\\."
+        }
+      ]
+    }
+  },
+  "scopeName": "source.imitator"
 }


### PR DESCRIPTION
This PR add the synclab token as a keyword. It also fix the problem when you have the following code

```
init := loc[sender]=idleS
end
```
In that case the token "end" is highlighted instead of the last end.